### PR TITLE
Feature: Online preview for Blazor3D

### DIFF
--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -3,7 +3,7 @@ name: Deploy to GitHub Pages
 # Run workflow on every push to the master branch
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   deploy-to-github-pages:

--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -1,0 +1,43 @@
+name: Deploy to GitHub Pages
+
+# Run workflow on every push to the master branch
+on:
+  push:
+    branches: [ master ]
+
+jobs:
+  deploy-to-github-pages:
+    # use ubuntu-latest image to run steps on
+    runs-on: ubuntu-latest
+    steps:
+    # uses GitHub's checkout action to checkout code form the master branch
+    - uses: actions/checkout@v2
+    
+    # sets up .NET Core SDK 3.1
+    - name: Setup .NET Core SDK
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 6.x
+
+    # publishes Blazor project to the release-folder
+    - name: Publish .NET Core Project
+      run: dotnet publish ./Examples/Blazor3D.Examples.WebAsm/Blazor3D.Examples.WebAsm.csproj -c Release -o release --nologo
+    
+    # changes the base-tag in index.html from '/' to 'Blazor3D' to match GitHub Pages repository subdirectory
+    - name: Change base-tag in index.html from / to Blazor3D
+      run: sed -i 's/<base href="\/" \/>/<base href="\/Blazor3D\/" \/>/g' release/wwwroot/index.html
+    
+    # copy index.html to 404.html to serve the same file when a file is not found
+    - name: copy index.html to 404.html
+      run: cp release/wwwroot/index.html release/wwwroot/404.html
+
+    # add .nojekyll file to tell GitHub pages to not treat this as a Jekyll project. (Allow files and folders starting with an underscore)
+    - name: Add .nojekyll file
+      run: touch release/wwwroot/.nojekyll
+      
+    - name: Commit wwwroot to GitHub Pages
+      uses: JamesIves/github-pages-deploy-action@3.7.1
+      with:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        BRANCH: gh-pages
+        FOLDER: release/wwwroot


### PR DESCRIPTION
QA: Is this the onlt thing i need to do?
- Nope you gotta turn on 2 settings.
1) in Setting->Actions-> Workflow Permissions you have to turn on the option to allow the action to make the branch "gh-pages"
![image](https://user-images.githubusercontent.com/64896329/221410179-d07e0b0b-2d51-4aa7-a4dd-3b078c2b4678.png)
2) after the first build set the GH pages branch in Settings -> Pages -> Github Pages -> set "Source" to Deploy from Branch, and select gh-Pages (if it is not there there has to be a small commit to activate it) 
![image](https://user-images.githubusercontent.com/64896329/221410257-3b7e9d7d-7826-45c1-ae82-0ca4d1c41934.png)

voilla 
https://hugovg.github.io/Blazor3D/example01

btw, nice library :)